### PR TITLE
Swift syntax updates to resolve compile errors (6.1 6A1052d)

### DIFF
--- a/camera/CameraManager.swift
+++ b/camera/CameraManager.swift
@@ -111,7 +111,7 @@ class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate {
                 for  device in devices  {
                     let captureDevice = device as AVCaptureDevice
                     if (captureDevice.position == AVCaptureDevicePosition.Back) {
-                        let avFlashMode = AVCaptureFlashMode.fromRaw(newflashMode.toRaw())
+                        let avFlashMode = AVCaptureFlashMode(rawValue: newflashMode.rawValue)
                         if (captureDevice.isFlashModeSupported(avFlashMode!)) {
                             captureDevice.lockForConfiguration(nil)
                             captureDevice.flashMode = avFlashMode!
@@ -237,7 +237,7 @@ class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate {
         if NSFileManager.defaultManager().fileExistsAtPath(tempPath!) {
             NSFileManager.defaultManager().removeItemAtPath(tempPath!, error: nil)
         }
-        return NSURL(fileURLWithPath: tempPath!)
+        return NSURL(fileURLWithPath: tempPath!)!
         }()
     
     /// CameraManager singleton instance to use the camera.
@@ -360,7 +360,7 @@ class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate {
                                         }
                                     }
                                 }
-                                imageCompletition(UIImage(data: imageData))
+                                imageCompletition(UIImage(data: imageData)!)
                             }
                         })
                     }

--- a/camera/ViewController.swift
+++ b/camera/ViewController.swift
@@ -50,7 +50,7 @@ class ViewController: UIViewController {
 
     @IBAction func changeFlashMode(sender: UIButton)
     {
-        self.cameraManager.flashMode = CameraFlashMode.fromRaw((self.cameraManager.flashMode.toRaw()+1)%3)!
+        self.cameraManager.flashMode = CameraFlashMode(rawValue: (self.cameraManager.flashMode.rawValue+1)%3)!
         switch (self.cameraManager.flashMode) {
         case .Off:
             sender.setTitle("Flash Off", forState: UIControlState.Normal)


### PR DESCRIPTION
This is to resolve compile errors in the latest Xcode and Swift compiler. Looks like Apple changed some signatures and started enforcing unwrapping optionals. 

Unrelated, the Pod doesn't compile, although that could be because Xcode is being cranky.
