### PR TITLE
fixed wrong orientation when camera preview starts in landscape mode

### DIFF
--- a/camera/CameraManager.swift
+++ b/camera/CameraManager.swift
@@ -487,6 +487,7 @@ class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate {
                     validCaptureSession.startRunning()
                     self._startFollowingDeviceOrientation()
                     self.cameraIsSetup = true
+                    self._orientationChanged()
 
                     completition()
                 }


### PR DESCRIPTION
In landscape mode, the camera preview shows in portrait mode. Calling orientationChanged to detect initial orientation.