### PR TITLE
Use a most effective way to retrieve real interface orientation.

### DIFF
--- a/camera/CameraManager.swift
+++ b/camera/CameraManager.swift
@@ -593,7 +593,7 @@ public class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGe
     }
 
     private func _currentVideoOrientation() -> AVCaptureVideoOrientation {
-        switch UIDevice.currentDevice().orientation {
+        switch UIApplication.sharedApplication().statusBarOrientation {
         case .LandscapeLeft:
             return .LandscapeRight
         case .LandscapeRight:


### PR DESCRIPTION
UIDevice.currentDevice().orientation returns the orientation of device.
UIApplication.sharedApplication().statusBarOrientation returns the
orientation of UI interface.
For example.
1. check out Portrait only in info.plist.
2. Setup shouldRespondToOrientationChanges=false.
3. Launch app with LandscapeLeft.
Intent: orientation is .Portrait
Actually: orientation is .LandscapeLeft