### PR TITLE
Fixes possible hang after requesting permission

### DIFF
--- a/camera/CameraManager.swift
+++ b/camera/CameraManager.swift
@@ -254,12 +254,12 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
         AVCaptureDevice.requestAccess(forMediaType: AVMediaTypeVideo, completionHandler: { (allowedAccess) -> Void in
             if self.cameraOutputMode == .videoWithMic {
                 AVCaptureDevice.requestAccess(forMediaType: AVMediaTypeAudio, completionHandler: { (allowedAccess) -> Void in
-                    DispatchQueue.main.sync(execute: { () -> Void in
+                    DispatchQueue.main.async(execute: { () -> Void in
                         completion(allowedAccess)
                     })
                 })
             } else {
-                DispatchQueue.main.sync(execute: { () -> Void in
+                DispatchQueue.main.async(execute: { () -> Void in
                     completion(allowedAccess)
                 })
 


### PR DESCRIPTION
Hi, it seems that there may be a hang after requesting permission.

According to [the document](https://developer.apple.com/reference/avfoundation/avcapturedevice/1624584-requestaccess), the `completionHandler` is called on "an arbitrary dispatch queue". If it is called on the main dispatch queue, the closure will not be executed until the `completionHandler` is executed.

Changing the call from `sync` to `async` fixes the problem. Many other camera libraries use `async` here as well.