### PR TITLE
New option to flip image took by front camera

### DIFF
--- a/camera/CameraManager.swift
+++ b/camera/CameraManager.swift
@@ -36,21 +36,21 @@ public enum CameraOutputQuality: Int {
 
 /// Class for handling iDevices custom camera usage
 open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGestureRecognizerDelegate {
-
+    
     // MARK: - Public properties
-
+    
     /// Capture session to customize camera settings.
     open var captureSession: AVCaptureSession?
-
+    
     /// Property to determine if the manager should show the error for the user. If you want to show the errors yourself set this to false. If you want to add custom error UI set showErrorBlock property. Default value is false.
     open var showErrorsToUsers = false
-
+    
     /// Property to determine if the manager should show the camera permission popup immediatly when it's needed or you want to show it manually. Default value is true. Be carful cause using the camera requires permission, if you set this value to false and don't ask manually you won't be able to use the camera.
     open var showAccessPermissionPopupAutomatically = true
-
+    
     /// A block creating UI to present error message to the user. This can be customised to be presented on the Window root view controller, or to pass in the viewController which will present the UIAlertController, for example.
     open var showErrorBlock:(_ erTitle: String, _ erMessage: String) -> Void = { (erTitle: String, erMessage: String) -> Void in
-
+        
         //        var alertController = UIAlertController(title: erTitle, message: erMessage, preferredStyle: .Alert)
         //        alertController.addAction(UIAlertAction(title: "OK", style: UIAlertActionStyle.Default, handler: { (alertAction) -> Void in  }))
         //
@@ -58,10 +58,10 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
         //            topController.presentViewController(alertController, animated: true, completion:nil)
         //        }
     }
-
+    
     /// Property to determine if manager should write the resources to the phone library. Default value is true.
     open var writeFilesToPhoneLibrary = true
-
+    
     /// Property to determine if manager should follow device orientation. Default value is true.
     open var shouldRespondToOrientationChanges = true {
         didSet {
@@ -73,21 +73,24 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
         }
     }
     
+    /// Property to determine if manager should horizontally flip image took by front camera. Default value is false.
+    open var shouldFlipFrontCameraImage = false
+    
     open var shouldKeepViewAtOrientationChanges = false
-
+    
     /// The Bool property to determine if the camera is ready to use.
     open var cameraIsReady: Bool {
         get {
             return cameraIsSetup
         }
     }
-
+    
     /// The Bool property to determine if current device has front camera.
     open var hasFrontCamera: Bool = {
         let frontDevices = AVCaptureDevice.videoDevices.filter { $0.position == .front }
         return !frontDevices.isEmpty
     }()
-
+    
     /// The Bool property to determine if current device has flash.
     open var hasFlash: Bool = {
         let hasFlashDevices = AVCaptureDevice.videoDevices.filter { $0.hasFlash }
@@ -97,7 +100,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
     /// Property to enable or disable switch animation
     
     open var animateCameraDeviceChange: Bool = true
-
+    
     /// Property to change camera device between front and back.
     open var cameraDevice = CameraDevice.back {
         didSet {
@@ -113,7 +116,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             }
         }
     }
-
+    
     /// Property to change camera flash mode.
     open var flashMode = CameraFlashMode.off {
         didSet {
@@ -124,7 +127,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             }
         }
     }
-
+    
     /// Property to change camera output quality.
     open var cameraOutputQuality = CameraOutputQuality.high {
         didSet {
@@ -135,7 +138,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             }
         }
     }
-
+    
     /// Property to change camera output.
     open var cameraOutputMode = CameraOutputMode.stillImage {
         didSet {
@@ -148,47 +151,47 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             }
         }
     }
-
+    
     /// Property to check video recording duration when in progress
     open var recordedDuration : CMTime { return movieOutput?.recordedDuration ?? kCMTimeZero }
-
+    
     /// Property to check video recording file size when in progress
     open var recordedFileSize : Int64 { return movieOutput?.recordedFileSize ?? 0 }
-
-
+    
+    
     // MARK: - Private properties
     
     fileprivate var locationManager = CameraLocationManager()
-
+    
     fileprivate weak var embeddingView: UIView?
     fileprivate var videoCompletion: ((_ videoURL: URL?, _ error: NSError?) -> Void)?
-
+    
     fileprivate var sessionQueue: DispatchQueue = DispatchQueue(label: "CameraSessionQueue", attributes: [])
-
+    
     fileprivate lazy var frontCameraDevice: AVCaptureDevice? = {
         return AVCaptureDevice.videoDevices.filter { $0.position == .front }.first
     }()
-
+    
     fileprivate lazy var backCameraDevice: AVCaptureDevice? = {
         return AVCaptureDevice.videoDevices.filter { $0.position == .back }.first
     }()
-
+    
     fileprivate lazy var mic: AVCaptureDevice? = {
         return AVCaptureDevice.defaultDevice(withMediaType: AVMediaTypeAudio)
     }()
-
+    
     fileprivate var stillImageOutput: AVCaptureStillImageOutput?
     fileprivate var movieOutput: AVCaptureMovieFileOutput?
     fileprivate var previewLayer: AVCaptureVideoPreviewLayer?
     fileprivate var library: PHPhotoLibrary?
-
+    
     fileprivate var cameraIsSetup = false
     fileprivate var cameraIsObservingDeviceOrientation = false
-
+    
     fileprivate var zoomScale       = CGFloat(1.0)
     fileprivate var beginZoomScale  = CGFloat(1.0)
     fileprivate var maxZoomScale    = CGFloat(1.0)
-
+    
     fileprivate var tempFilePath: URL = {
         let tempURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("tempMovie").appendingPathExtension("mp4")
         let tempPath = tempURL.absoluteString
@@ -199,17 +202,17 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
         }
         return tempURL
     }()
-
-
+    
+    
     // MARK: - CameraManager
-
+    
     /**
      Inits a capture session and adds a preview layer to the given view. Preview layer bounds will automaticaly be set to match given view. Default session is initialized with still image output.
-
+     
      :param: view The view you want to add the preview layer to
      :param: cameraOutputMode The mode you want capturesession to run image / video / video and microphone
      :param: completion Optional completion block
-
+     
      :returns: Current state of the camera: Ready / AccessDenied / NoDeviceFound / NotDetermined.
      */
     open func addPreviewLayerToView(_ view: UIView) -> CameraState {
@@ -218,7 +221,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
     open func addPreviewLayerToView(_ view: UIView, newCameraOutputMode: CameraOutputMode) -> CameraState {
         return addLayerPreviewToView(view, newCameraOutputMode: newCameraOutputMode, completion: nil)
     }
-
+    
     open func addLayerPreviewToView(_ view: UIView, newCameraOutputMode: CameraOutputMode, completion: ((Void) -> Void)?) -> CameraState {
         if _canLoadCamera() {
             if let _ = embeddingView {
@@ -244,10 +247,10 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
         }
         return _checkIfCameraIsAvailable()
     }
-
+    
     /**
      Asks the user for camera permissions. Only works if the permissions are not yet determined. Note that it'll also automaticaly ask about the microphone permissions if you selected VideoWithMic output.
-
+     
      :param: completion Completion block with the result of permission request
      */
     open func askUserForCameraPermission(_ completion: @escaping (Bool) -> Void) {
@@ -262,11 +265,11 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
                 DispatchQueue.main.sync(execute: { () -> Void in
                     completion(allowedAccess)
                 })
-
+                
             }
         })
     }
-
+    
     /**
      Stops running capture session but all setup devices, inputs and outputs stay for further reuse.
      */
@@ -274,7 +277,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
         captureSession?.stopRunning()
         _stopFollowingDeviceOrientation()
     }
-
+    
     /**
      Resumes capture session.
      */
@@ -298,7 +301,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             }
         }
     }
-
+    
     /**
      Stops running capture session and removes all setup devices, inputs and outputs.
      */
@@ -317,32 +320,41 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
         movieOutput = nil
         animateCameraDeviceChange = oldAnimationValue
     }
-
+    
     /**
      Captures still image from currently running capture session.
-
+     
      :param: imageCompletion Completion block containing the captured UIImage
      */
     open func capturePictureWithCompletion(_ imageCompletion: @escaping (UIImage?, NSError?) -> Void) {
         self.capturePictureDataWithCompletion { data, error in
-
+            
             guard error == nil, let imageData = data else {
                 imageCompletion(nil, error)
                 return
             }
             
             self._performShutterAnimation() {
-                if self.writeFilesToPhoneLibrary == true, let library = self.library  {
-                    guard var flippedImage = UIImage(data: imageData) else {
+                guard let tempImage = UIImage(data: imageData) else {
+                    imageCompletion(nil, NSError())
+                    return
+                }
+                
+                let image: UIImage
+                if self.shouldFlipFrontCameraImage == true, self.cameraDevice == .front {
+                    guard let cgImage = tempImage.cgImage else {
                         imageCompletion(nil, NSError())
                         return
                     }
-                    if self.cameraDevice == .front, let cgImage = flippedImage.cgImage {
-                        flippedImage = UIImage(cgImage: cgImage, scale: (flippedImage.scale), orientation:.rightMirrored)
-                    }
-                    
+                    let flippedImage = UIImage(cgImage: cgImage, scale: tempImage.scale, orientation: .leftMirrored)
+                    image = flippedImage
+                } else {
+                    image = tempImage
+                }
+                
+                if self.writeFilesToPhoneLibrary == true, let library = self.library  {
                     library.performChanges({
-                        let request = PHAssetChangeRequest.creationRequestForAsset(from: flippedImage)
+                        let request = PHAssetChangeRequest.creationRequestForAsset(from: image)
                         request.creationDate = Date()
                         
                         if let location = self.locationManager.latestLocation {
@@ -356,32 +368,33 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
                         }
                     })
                 }
-                imageCompletion(UIImage(data: imageData), nil)
+                
+                imageCompletion(image, nil)
             }
         }
     }
-
+    
     /**
      Captures still image from currently running capture session.
-
+     
      :param: imageCompletion Completion block containing the captured imageData
      */
     open func capturePictureDataWithCompletion(_ imageCompletion: @escaping (Data?, NSError?) -> Void) {
-
+        
         guard cameraIsSetup else {
             _show(NSLocalizedString("No capture session setup", comment:""), message: NSLocalizedString("I can't take any picture", comment:""))
             return
         }
-
+        
         guard cameraOutputMode == .stillImage else {
             _show(NSLocalizedString("Capture session output mode video", comment:""), message: NSLocalizedString("I can't take any picture", comment:""))
             return
         }
-
+        
         sessionQueue.async(execute: {
             let stillImageOutput = self._getStillImageOutput()
             stillImageOutput.captureStillImageAsynchronously(from: stillImageOutput.connection(withMediaType: AVMediaTypeVideo), completionHandler: { [weak self] sample, error in
-
+                
                 if let error = error {
                     DispatchQueue.main.async(execute: {
                         self?._show(NSLocalizedString("Error", comment:""), message: error.localizedDescription)
@@ -389,15 +402,15 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
                     imageCompletion(nil, error as NSError?)
                     return
                 }
-
+                
                 let imageData = AVCaptureStillImageOutput.jpegStillImageNSDataRepresentation(sample)
                 imageCompletion(imageData, nil)
-
-                })
+                
+            })
         })
-
+        
     }
-
+    
     /**
      Starts recording a video with or without voice as in the session preset.
      */
@@ -408,7 +421,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             _show(NSLocalizedString("Capture session output still image", comment:""), message: NSLocalizedString("I can only take pictures", comment:""))
         }
     }
-
+    
     /**
      Stop recording a video. Save it to the cameraRoll and give back the url.
      */
@@ -420,19 +433,19 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             }
         }
     }
-
+    
     /**
      Current camera status.
-
+     
      :returns: Current state of the camera: Ready / AccessDenied / NoDeviceFound / NotDetermined
      */
     open func currentCameraStatus() -> CameraState {
         return _checkIfCameraIsAvailable()
     }
-
+    
     /**
      Change current flash mode to next value from available ones.
-
+     
      :returns: Current flash mode: Off / On / Auto
      */
     open func changeFlashMode() -> CameraFlashMode {
@@ -440,10 +453,10 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
         flashMode = newFlashMode
         return flashMode
     }
-
+    
     /**
      Change current output quality mode to next value from available ones.
-
+     
      :returns: Current quality mode: Low / Medium / High
      */
     open func changeQualityMode() -> CameraOutputQuality {
@@ -451,9 +464,9 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
         cameraOutputQuality = newQuality
         return cameraOutputQuality
     }
-
+    
     // MARK: - AVCaptureFileOutputRecordingDelegate
-
+    
     open func capture(_ captureOutput: AVCaptureFileOutput?, didStartRecordingToOutputFileAt fileURL: URL?, fromConnections connections: [Any]?) {
         captureSession?.beginConfiguration()
         if flashMode != .off {
@@ -461,16 +474,16 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
         }
         captureSession?.commitConfiguration()
     }
-
+    
     open func capture(_ captureOutput: AVCaptureFileOutput?, didFinishRecordingToOutputFileAt outputFileURL: URL?, fromConnections connections: [Any]?, error: Error?) {
         _updateTorch(.off)
         if let error = error {
             _show(NSLocalizedString("Unable to save video to the iPhone", comment:""), message: error.localizedDescription)
         }
         else {
-
+            
             if let outputFileURL = outputFileURL, writeFilesToPhoneLibrary {
-
+                
                 if PHPhotoLibrary.authorizationStatus() == .authorized {
                     saveVideoToLibrary(outputFileURL)
                 }
@@ -481,55 +494,55 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
                         }
                     })
                 }
-
+                
             } else {
                 _executeVideoCompletionWithURL(outputFileURL, error: error as NSError?)
             }
         }
     }
-
+    
     fileprivate func saveVideoToLibrary(_ fileURL: URL) {
         if let validLibrary = library {
             validLibrary.performChanges({
-
+                
                 PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: fileURL)
-                }, completionHandler: { success, error in
-                    if let error = error {
-                        self._show(NSLocalizedString("Unable to save video to the iPhone.", comment:""), message: error.localizedDescription)
-                        self._executeVideoCompletionWithURL(nil, error: error as NSError?)
-                    } else {
-                        self._executeVideoCompletionWithURL(fileURL, error: error as NSError?)
-                    }
+            }, completionHandler: { success, error in
+                if let error = error {
+                    self._show(NSLocalizedString("Unable to save video to the iPhone.", comment:""), message: error.localizedDescription)
+                    self._executeVideoCompletionWithURL(nil, error: error as NSError?)
+                } else {
+                    self._executeVideoCompletionWithURL(fileURL, error: error as NSError?)
+                }
             })
         }
     }
-
+    
     // MARK: - UIGestureRecognizerDelegate
-
+    
     fileprivate func attachZoom(_ view: UIView) {
         let pinch = UIPinchGestureRecognizer(target: self, action: #selector(CameraManager._zoomStart(_:)))
         view.addGestureRecognizer(pinch)
         pinch.delegate = self
     }
-
+    
     open func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-
+        
         if gestureRecognizer.isKind(of: UIPinchGestureRecognizer.self) {
             beginZoomScale = zoomScale;
         }
-
+        
         return true
     }
-
+    
     @objc
     fileprivate func _zoomStart(_ recognizer: UIPinchGestureRecognizer) {
         guard let view = embeddingView,
             let previewLayer = previewLayer
             else { return }
-
+        
         var allTouchesOnPreviewLayer = true
         let numTouch = recognizer.numberOfTouches
-
+        
         for i in 0 ..< numTouch {
             let location = recognizer.location(ofTouch: i, in: view)
             let convertedTouch = previewLayer.convert(location, from: previewLayer.superlayer)
@@ -542,18 +555,18 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             _zoom(recognizer.scale)
         }
     }
-
+    
     fileprivate func _zoom(_ scale: CGFloat) {
         do {
             let captureDevice = AVCaptureDevice.devices().first as? AVCaptureDevice
             try captureDevice?.lockForConfiguration()
-
+            
             zoomScale = max(1.0, min(beginZoomScale * scale, maxZoomScale))
-
+            
             captureDevice?.videoZoomFactor = zoomScale
-
+            
             captureDevice?.unlockForConfiguration()
-
+            
         } catch {
             print("Error locking configuration")
         }
@@ -580,10 +593,10 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
         
         if let validDevice = device {
             
-//            if validDevice.isAdjustingFocus || validDevice.isAdjustingExposure || showingFocusRectangle {
-//                
-//                return
-//            }
+            //            if validDevice.isAdjustingFocus || validDevice.isAdjustingExposure || showingFocusRectangle {
+            //
+            //                return
+            //            }
             
             if let validPreviewLayer = previewLayer,
                 let view = recognizer.view
@@ -690,9 +703,9 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
         CATransaction.commit()
     }
     
-
+    
     // MARK: - CameraManager()
-
+    
     fileprivate func _updateTorch(_ flashMode: CameraFlashMode) {
         captureSession?.beginConfiguration()
         defer { captureSession?.commitConfiguration() }
@@ -710,15 +723,15 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             }
         }
     }
-
-
+    
+    
     fileprivate func _executeVideoCompletionWithURL(_ url: URL?, error: NSError?) {
         if let validCompletion = videoCompletion {
             validCompletion(url, error)
             videoCompletion = nil
         }
     }
-
+    
     fileprivate func _getMovieOutput() -> AVCaptureMovieFileOutput {
         if let movieOutput = movieOutput, let connection = movieOutput.connection(withMediaType: AVMediaTypeVideo),
             connection.isActive {
@@ -736,7 +749,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
         }
         return newMoviewOutput
     }
-
+    
     fileprivate func _getStillImageOutput() -> AVCaptureStillImageOutput {
         if let stillImageOutput = stillImageOutput, let connection = stillImageOutput.connection(withMediaType: AVMediaTypeVideo),
             connection.isActive {
@@ -753,7 +766,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
         }
         return newStillImageOutput
     }
-
+    
     @objc fileprivate func _orientationChanged() {
         var currentConnection: AVCaptureConnection?;
         switch cameraOutputMode {
@@ -784,7 +797,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             }
         }
     }
-
+    
     fileprivate func _currentVideoOrientation() -> AVCaptureVideoOrientation {
         switch UIDevice.current.orientation {
         case .landscapeLeft:
@@ -795,15 +808,15 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             return .portrait
         }
     }
-
+    
     fileprivate func _canLoadCamera() -> Bool {
         let currentCameraState = _checkIfCameraIsAvailable()
         return currentCameraState == .ready || (currentCameraState == .notDetermined && showAccessPermissionPopupAutomatically)
     }
-
+    
     fileprivate func _setupCamera(_ completion: @escaping (Void) -> Void) {
         captureSession = AVCaptureSession()
-
+        
         sessionQueue.async(execute: {
             if let validCaptureSession = self.captureSession {
                 validCaptureSession.beginConfiguration()
@@ -819,26 +832,26 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
                 self._startFollowingDeviceOrientation()
                 self.cameraIsSetup = true
                 self._orientationChanged()
-
+                
                 completion()
             }
         })
     }
-
+    
     fileprivate func _startFollowingDeviceOrientation() {
         if shouldRespondToOrientationChanges && !cameraIsObservingDeviceOrientation {
             NotificationCenter.default.addObserver(self, selector: #selector(CameraManager._orientationChanged), name: NSNotification.Name.UIDeviceOrientationDidChange, object: nil)
             cameraIsObservingDeviceOrientation = true
         }
     }
-
+    
     fileprivate func _stopFollowingDeviceOrientation() {
         if cameraIsObservingDeviceOrientation {
             NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIDeviceOrientationDidChange, object: nil)
             cameraIsObservingDeviceOrientation = false
         }
     }
-
+    
     fileprivate func _addPreviewLayerToView(_ view: UIView) {
         embeddingView = view
         attachZoom(view)
@@ -850,21 +863,21 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             view.layer.addSublayer(previewLayer)
         })
     }
-
+    
     fileprivate func _setupMaxZoomScale() {
         var maxZoom = CGFloat(1.0)
         beginZoomScale = CGFloat(1.0)
-
+        
         if cameraDevice == .back, let backCameraDevice = backCameraDevice  {
             maxZoom = backCameraDevice.activeFormat.videoMaxZoomFactor
         }
         else if cameraDevice == .front, let frontCameraDevice = frontCameraDevice {
             maxZoom = frontCameraDevice.activeFormat.videoMaxZoomFactor
         }
-
+        
         maxZoomScale = maxZoom
     }
-
+    
     fileprivate func _checkIfCameraIsAvailable() -> CameraState {
         let deviceHasCamera = UIImagePickerController.isCameraDeviceAvailable(UIImagePickerControllerCameraDevice.rear) || UIImagePickerController.isCameraDeviceAvailable(UIImagePickerControllerCameraDevice.front)
         if deviceHasCamera {
@@ -883,10 +896,10 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             return .noDeviceFound
         }
     }
-
+    
     fileprivate func _setupOutputMode(_ newCameraOutputMode: CameraOutputMode, oldCameraOutputMode: CameraOutputMode?) {
         captureSession?.beginConfiguration()
-
+        
         if let cameraOutputToRemove = oldCameraOutputMode {
             // remove current setting
             switch cameraOutputToRemove {
@@ -903,7 +916,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
                 }
             }
         }
-
+        
         // configure new devices
         switch newCameraOutputMode {
         case .stillImage:
@@ -924,7 +937,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
                     captureSession.addOutput(videoMovieOutput)
                 }
             }
-
+            
             if newCameraOutputMode == .videoWithMic {
                 if let validMic = _deviceInputFromDevice(mic) {
                     captureSession?.addInput(validMic)
@@ -935,7 +948,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
         _updateCameraQualityMode(cameraOutputQuality)
         _orientationChanged()
     }
-
+    
     fileprivate func _setupOutputs() {
         if (stillImageOutput == nil) {
             stillImageOutput = AVCaptureStillImageOutput()
@@ -948,7 +961,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             library = PHPhotoLibrary.shared()
         }
     }
-
+    
     fileprivate func _setupPreviewLayer() {
         if let validCaptureSession = captureSession {
             previewLayer = AVCaptureVideoPreviewLayer(session: validCaptureSession)
@@ -987,9 +1000,9 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
                 }
                 
                 validEmbeddingView.insertSubview(tempView, at: Int(validPreviewLayer.zPosition + 1))
-
+                
                 cameraTransitionView = validEmbeddingView.snapshotView(afterScreenUpdates: true)
-
+                
                 if let cameraTransitionView = cameraTransitionView {
                     validEmbeddingView.insertSubview(cameraTransitionView, at: Int(validEmbeddingView.layer.zPosition + 1))
                 }
@@ -1005,34 +1018,34 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             }
         }
     }
-
+    
     // MARK: - CameraLocationManager()
-
+    
     fileprivate class CameraLocationManager: NSObject, CLLocationManagerDelegate {
         var locationManager = CLLocationManager()
         var latestLocation: CLLocation?
-
+        
         override init() {
             super.init()
             locationManager.delegate = self
             locationManager.desiredAccuracy = kCLLocationAccuracyBest
             locationManager.requestWhenInUseAuthorization()
         }
-
+        
         func startUpdatingLocation() {
             locationManager.startUpdatingLocation()
         }
-
+        
         func stopUpdatingLocation() {
             locationManager.stopUpdatingLocation()
         }
-
+        
         // MARK: - CLLocationManagerDelegate
         func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
             // Pick the location with best (= smallest value) horizontal accuracy
             latestLocation = locations.sorted { $0.horizontalAccuracy < $1.horizontalAccuracy }.first
         }
-
+        
         func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
             if status == .authorizedAlways || status == .authorizedWhenInUse {
                 locationManager.startUpdatingLocation()
@@ -1109,22 +1122,22 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
                             
                             cameraTransitionView.alpha = 0.0
                             
-                }, completion: { (finished) -> Void in
-                    
-                    self.transitionAnimating = false
-                    
-                    cameraTransitionView.removeFromSuperview()
-                    self.cameraTransitionView = nil
+            }, completion: { (finished) -> Void in
+                
+                self.transitionAnimating = false
+                
+                cameraTransitionView.removeFromSuperview()
+                self.cameraTransitionView = nil
             })
         }
     }
-
+    
     fileprivate func _updateCameraDevice(_ deviceType: CameraDevice) {
         if let validCaptureSession = captureSession {
             validCaptureSession.beginConfiguration()
             defer { validCaptureSession.commitConfiguration() }
             let inputs: [AVCaptureInput] = validCaptureSession.inputs?.flatMap { $0 as? AVCaptureInput } ?? []
-
+            
             for input in inputs {
                 if let deviceInput = input as? AVCaptureDeviceInput {
                     if deviceInput.device == backCameraDevice && cameraDevice == .front {
@@ -1154,7 +1167,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             }
         }
     }
-
+    
     fileprivate func _updateFlasMode(_ flashMode: CameraFlashMode) {
         captureSession?.beginConfiguration()
         defer { captureSession?.commitConfiguration() }
@@ -1204,7 +1217,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             }
         }
     }
-
+    
     fileprivate func _updateCameraQualityMode(_ newCameraOutputQuality: CameraOutputQuality) {
         if let validCaptureSession = captureSession {
             var sessionPreset = AVCaptureSessionPresetLow
@@ -1231,10 +1244,10 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             _show(NSLocalizedString("Camera error", comment:""), message: NSLocalizedString("No valid capture session found, I can't take any pictures or videos.", comment:""))
         }
     }
-
+    
     fileprivate func _removeMicInput() {
         guard let inputs = captureSession?.inputs as? [AVCaptureInput] else { return }
-
+        
         for input in inputs {
             if let deviceInput = input as? AVCaptureDeviceInput {
                 if deviceInput.device == mic {
@@ -1244,7 +1257,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             }
         }
     }
-
+    
     fileprivate func _show(_ title: String, message: String) {
         if showErrorsToUsers {
             DispatchQueue.main.async(execute: { () -> Void in
@@ -1252,7 +1265,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             })
         }
     }
-
+    
     fileprivate func _deviceInputFromDevice(_ device: AVCaptureDevice?) -> AVCaptureDeviceInput? {
         guard let validDevice = device else { return nil }
         do {


### PR DESCRIPTION
Added `shouldFlipFrontCameraImage` instance property on `CameraManager`, so that developers can decide whether to flip image took by front camera or not.

Default value is `false` so that default behavior won't change from previous versions of this library.

This resolves #102.