### PR TITLE
Add gesture recognizers on the main thread

### DIFF
--- a/camera/CameraManager.swift
+++ b/camera/CameraManager.swift
@@ -880,8 +880,8 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
     
     fileprivate func _addPreviewLayerToView(_ view: UIView) {
         embeddingView = view
-        self.attachZoom(view)
-        self.attachFocus(view)
+        attachZoom(view)
+        attachFocus(view)
         DispatchQueue.main.async(execute: { () -> Void in
             guard let previewLayer = self.previewLayer else { return }
             previewLayer.frame = view.layer.bounds

--- a/camera/CameraManager.swift
+++ b/camera/CameraManager.swift
@@ -623,9 +623,11 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
     fileprivate lazy var focusGesture = UITapGestureRecognizer()
     
     fileprivate func attachFocus(_ view: UIView) {
-        focusGesture.addTarget(self, action: #selector(CameraManager._focusStart(_:)))
-        view.addGestureRecognizer(focusGesture)
-        focusGesture.delegate = self
+        DispatchQueue.main.async {
+            self.zoomGesture.addTarget(self, action: #selector(CameraManager._zoomStart(_:)))
+            view.addGestureRecognizer(self.focusGesture)
+            self.zoomGesture.delegate = self
+        }
     }
     
     @objc fileprivate func _focusStart(_ recognizer: UITapGestureRecognizer) {
@@ -878,9 +880,9 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
     
     fileprivate func _addPreviewLayerToView(_ view: UIView) {
         embeddingView = view
+        self.attachZoom(view)
+        self.attachFocus(view)
         DispatchQueue.main.async(execute: { () -> Void in
-            self.attachZoom(view)
-            self.attachFocus(view)
             guard let previewLayer = self.previewLayer else { return }
             previewLayer.frame = view.layer.bounds
             view.clipsToBounds = true

--- a/camera/CameraManager.swift
+++ b/camera/CameraManager.swift
@@ -878,9 +878,9 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
     
     fileprivate func _addPreviewLayerToView(_ view: UIView) {
         embeddingView = view
-        attachZoom(view)
-        attachFocus(view)
         DispatchQueue.main.async(execute: { () -> Void in
+            self.attachZoom(view)
+            self.attachFocus(view)
             guard let previewLayer = self.previewLayer else { return }
             previewLayer.frame = view.layer.bounds
             view.clipsToBounds = true


### PR DESCRIPTION
## What was done
Moved the adding of gesture recognizers in the CameraManager.swift file to the main thread.

## Why was it done
Intermittent crashes.
Xcode 9's thread checking feature was throwing an error each time I used the CameraManager saying that adding a gesture recognizer must be done on the main thread. XCode's static analyzer also showed a warning about this gesture recognizer and said it needed to be done on the main thread. 

## Testing
Run the CameraManager using Xcode 9 without this change and you should see the console print an error about adding a gesture recognizer on a background thread. If you build this branch that error should be resolved.