### PR TITLE
Add @discardableResult modifiers to addPreviewLayerToView

### DIFF
--- a/camera/CameraManager.swift
+++ b/camera/CameraManager.swift
@@ -240,14 +240,15 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
      
      :returns: Current state of the camera: Ready / AccessDenied / NoDeviceFound / NotDetermined.
      */
-    open func addPreviewLayerToView(_ view: UIView) -> CameraState {
+    @discardableResult open func addPreviewLayerToView(_ view: UIView) -> CameraState {
         return addPreviewLayerToView(view, newCameraOutputMode: cameraOutputMode)
     }
-    open func addPreviewLayerToView(_ view: UIView, newCameraOutputMode: CameraOutputMode) -> CameraState {
+  
+    @discardableResult open func addPreviewLayerToView(_ view: UIView, newCameraOutputMode: CameraOutputMode) -> CameraState {
         return addLayerPreviewToView(view, newCameraOutputMode: newCameraOutputMode, completion: nil)
     }
     
-    open func addLayerPreviewToView(_ view: UIView, newCameraOutputMode: CameraOutputMode, completion: (() -> Void)?) -> CameraState {
+    @discardableResult open func addLayerPreviewToView(_ view: UIView, newCameraOutputMode: CameraOutputMode, completion: (() -> Void)?) -> CameraState {
         if _canLoadCamera() {
             if let _ = embeddingView {
                 if let validPreviewLayer = previewLayer {

--- a/camera/ViewController.swift
+++ b/camera/ViewController.swift
@@ -68,7 +68,7 @@ class ViewController: UIViewController {
     
     fileprivate func addCameraToView()
     {
-        _ = cameraManager.addPreviewLayerToView(cameraView, newCameraOutputMode: CameraOutputMode.videoWithMic)
+        cameraManager.addPreviewLayerToView(cameraView, newCameraOutputMode: CameraOutputMode.videoWithMic)
         cameraManager.showErrorBlock = { [weak self] (erTitle: String, erMessage: String) -> Void in
         
             let alertController = UIAlertController(title: erTitle, message: erMessage, preferredStyle: .alert)


### PR DESCRIPTION
This PR adds the `@discardableResult` to the `addPreviewLayerToView` methods. This allows preventing the use of the discardable variable when you only need to add the preview layer and don't care for the camera state. So this:
```swift
_ = cameraManager.addPreviewLayerToView( // ...
```
can be rewritten as:
```swift
cameraManager.addPreviewLayerToView( // ...
```
with no compiler warnings.

Thank you for your work on this library.  

Fixes #126
