### PR TITLE
Using CoreMotion to get real device orientation, fixing no sound when switching camera

### DIFF
--- a/camera/CameraManager.swift
+++ b/camera/CameraManager.swift
@@ -1206,7 +1206,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
             let inputs: [AVCaptureInput] = validCaptureSession.inputs
             
             for input in inputs {
-                if let deviceInput = input as? AVCaptureDeviceInput {
+                if let deviceInput = input as? AVCaptureDeviceInput, deviceInput.device != mic {
                     validCaptureSession.removeInput(deviceInput)
                 }
             }


### PR DESCRIPTION
**Problem**

The library uses `UIDevice.current.orientation` to detect the device orientation. This does not work well when device orientation is locked by the user in iOS.  

When the user locks orientation in iOS, then `UIDevice.current.orientation` always return `.portrait` even when the user rotates the device to landscape. This results in an incorrectly rotated photo.

**Solution**

Use `CoreMotion` instead of `UIDevice.current.orientation` to detect real device orientation.

**Problem**

When you switch camera between front and back, the recorded video has no sound

**Solution**

Not removing the microphone device in `_updateCameraDevice`.