### PR TITLE
Change callbacks to the swifty way of reporting success and errors.

### DIFF
--- a/camera.xcodeproj/project.pbxproj
+++ b/camera.xcodeproj/project.pbxproj
@@ -206,7 +206,6 @@
 				TargetAttributes = {
 					454C1F4019E82E2500C81915 = {
 						CreatedOnToolsVersion = 6.0.1;
-						DevelopmentTeam = QM7HJTY23M;
 						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};

--- a/camera/CameraManager.swift
+++ b/camera/CameraManager.swift
@@ -488,7 +488,29 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
         self.movieOutput = nil
         self.animateCameraDeviceChange = oldAnimationValue
     }
-    
+
+    /**
+     Captures still image from currently running capture session.
+
+     :param: imageCompletion Completion block containing the captured UIImage
+     */
+    @available(*, deprecated)
+    open func capturePictureWithCompletion(_ imageCompletion: @escaping (UIImage?, NSError?) -> Void) {
+
+        func completion(_ result: CaptureResult) {
+
+            switch result {
+
+            case let .success(content):
+                imageCompletion(content.asImage, nil)
+            case .failure:
+                imageCompletion(nil, NSError())
+            }
+        }
+
+        capturePictureWithCompletion(completion)
+    }
+
     /**
      Captures still image from currently running capture session.
      
@@ -631,6 +653,27 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
     /**
      Captures still image from currently running capture session.
      
+     :param: imageCompletion Completion block containing the captured imageData
+     */
+    @available(*, deprecated)
+    open func capturePictureDataWithCompletion(_ imageCompletion: @escaping (Data?, NSError?) -> Void) {
+
+        func completion(_ result: CaptureResult) {
+
+            switch result {
+
+            case let .success(content):
+                imageCompletion(content.asData, nil)
+            case .failure:
+                imageCompletion(nil, NSError())
+            }
+        }
+        capturePictureDataWithCompletion(completion)
+    }
+
+    /**
+     Captures still image from currently running capture session.
+
      :param: imageCompletion Completion block containing the captured imageData
      */
     open func capturePictureDataWithCompletion(_ imageCompletion: @escaping (CaptureResult) -> Void) {

--- a/camera/ViewController.swift
+++ b/camera/ViewController.swift
@@ -138,14 +138,15 @@ class ViewController: UIViewController {
         
         switch cameraManager.cameraOutputMode {
         case .stillImage:
-            cameraManager.capturePictureWithCompletion({ (image, error) -> Void in
-                if error != nil {
+            cameraManager.capturePictureWithCompletion({ result in
+                switch result {
+                case .failure:
                     self.cameraManager.showErrorBlock("Error occurred", "Cannot save picture.")
-                }
-                else {
+                case .success(let content):
+
                     let vc: ImageViewController? = self.storyboard?.instantiateViewController(withIdentifier: "ImageVC") as? ImageViewController
                     if let validVC: ImageViewController = vc,
-                        let capturedImage = image {
+                        case let capturedImage = content.asImage {
                             validVC.image = capturedImage
                             validVC.cameraManager = self.cameraManager
                             self.navigationController?.pushViewController(validVC, animated: true)


### PR DESCRIPTION
Change callbacks to use enums to report success/failure.
This makes it possible to add reporting the PHAsset result of storing an image to the photo library.

It might be better to put the enums in a separate file... I can do that if needed.
