### PR TITLE
Change the main class to open to permit inheritance

### DIFF
--- a/Sources/CameraManager.swift
+++ b/Sources/CameraManager.swift
@@ -108,7 +108,7 @@ public enum CaptureError: Error {
 }
 
 /// Class for handling iDevices custom camera usage
-public class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGestureRecognizerDelegate {
+open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGestureRecognizerDelegate {
     // MARK: - Public properties
     
     // Property for custom image album name.


### PR DESCRIPTION
I changed the main class to permit inheritance, because the `public` behaviour changed recently and so we cannot inherit from a public class outside of his target. I worked perfectly before, but with recent update, it's not working anymore. 
I inherit from CameraManger for some of my project to catch the live feed and do object detection with ARKit. I need it ; )