### PR TITLE
Fixed qrOutput reference so cleanup works now

### DIFF
--- a/Sources/CameraManager.swift
+++ b/Sources/CameraManager.swift
@@ -799,10 +799,15 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
         guard let captureSession = self.captureSession
             else { return }
         
-        let output = AVCaptureMetadataOutput()
+        qrOutput = AVCaptureMetadataOutput()
         
-        guard captureSession.canAddOutput(output)
-            else { return }
+        guard let output = qrOutput else {
+            return
+        }
+
+        guard captureSession.canAddOutput(output) else {
+            return
+        }
         
         qrCodeDetectionHandler = handler
         captureSession.addOutput(output)
@@ -832,7 +837,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
     /**
      The stored meta data output; used to detect QR codes.
      */
-    private var qrOutput: AVCaptureOutput?
+    private var qrOutput: AVCaptureMetadataOutput?
     
     /**
      Check if the device rotation is locked


### PR DESCRIPTION
Fixed mistake in assigning `qrOutput` variable so when `stopQRCodeDetection()` is called, the output is removed from the capture session. The issue can be reproduced when you call `startQRCodeDetection()` then `stopQRCodeDetection()` and then `startQRCodeDetection()` again. No QR code is detected anymore.