### PR TITLE
Added missing callback when recording stops and the user don't give a…

### DIFF
--- a/Sources/CameraManager.swift
+++ b/Sources/CameraManager.swift
@@ -898,6 +898,8 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
                     PHPhotoLibrary.requestAuthorization { autorizationStatus in
                         if autorizationStatus == .authorized {
                             self._saveVideoToLibrary(outputFileURL)
+                        } else {
+                            _executeVideoCompletionWithURL(outputFileURL, error: error as NSError?)
                         }
                     }
                 }


### PR DESCRIPTION
It is missing a callback after the recording stops and the user don't give permissions to save the video to the Photo Library.

As the code is right now the callback is not performed when the user chooses not to give permissions for saving the video into the Photo Library. The callback is only called when the user gives permission and there's not callback to perform an action afterwards. It could be a good idea to maybe return an error when the writeFilesToPhoneLibrary flag is true and the user don't allows access to the Photo Library. 