### PR TITLE
Extend the startQRCodeDetection method to support customizing AVMetadataObject types.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 ## Build generated
 build/
 DerivedData
+.build
 
 ## Various settings
 *.pbxuser

--- a/Sources/CameraManager.swift
+++ b/Sources/CameraManager.swift
@@ -454,8 +454,15 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
      Stops running capture session but all setup devices, inputs and outputs stay for further reuse.
      */
     open func stopCaptureSession() {
-        captureSession?.stopRunning()
-        _stopFollowingDeviceOrientation()
+        if let validCaptureSession = captureSession {
+            if validCaptureSession.isRunning, cameraIsSetup {
+                sessionQueue.async { [weak self] in
+                    guard let self = self else { return }
+                    self.captureSession?.stopRunning()
+                    self._stopFollowingDeviceOrientation()
+                }
+            }
+        }
     }
     
     /**


### PR DESCRIPTION
**Bugfix:**
1.  fix a bug: the `qrOutput` doesn't get assigned in the `startQRCodeDetection`, after AVCaptureMetadataOutput creation  , which makes `stopQRCodeDetection` useless.

**Feature:**
1. Extend the `startQRCodeDetection` method with a `withTypes` parameter to provide the ability to customize the code recognition types instead of the const type array  `[.qr, .ean8, .ean13, .pdf417]`. And also provide a default value with the const types for `withTypes` parameter to make code compatible  with old versions.

**Optimize:**
1. Dispatch the session configuration operation into the `sessionQueue` to make it more efficient (will not affect the main thread).

2. Make the `qrOutput` property accessible and  type accurate, cause the user may need more configurations  with the output (for example, the `rectOfInterest`).